### PR TITLE
Avoiding unmappable character message

### DIFF
--- a/plugin/javaunit.vim
+++ b/plugin/javaunit.vim
@@ -25,7 +25,7 @@ let s:JavaUnit_TestMethod_Source = g:JavaUnit_Home .s:Fsep .join(['src','com','w
 lockvar! s:JavaUnit_Exec s:JavaUnit_TestMethod_Source g:JavaUnit_tempdir
 
 if findfile(g:JavaUnit_tempdir.join(['','com','wsdjeg','util','TestMethod.class'],s:Fsep))==""
-    silent exec '!javac -d "'.g:JavaUnit_tempdir.'" "'.s:JavaUnit_TestMethod_Source .'"'
+    silent exec '!javac -encoding utf8 -d "'.g:JavaUnit_tempdir.'" "'.s:JavaUnit_TestMethod_Source .'"'
 endif
 
 function JaveUnitTestMethod(args,...)


### PR DESCRIPTION
I use Cp1252 by default, so the comments on the java file were causing the following error:

```
TestMethod.java:5: error: unmappable character for encoding Cp1252
/**µ£¼þ▒╗õ©║javaµû╣µ│òµÁïÞ»òþ▒╗,õ¢┐þö¿Õë?Ú£ÇÕ░åÚ£ÇÞª?µÁïÞ»òþÜäµ║?µûçõ╗Âþ╝ûÞ»æµê?classµûçõ╗Â,õ╣ïÕ?ÄÞ┐?Þíî
```

So this pull makes sure that the file is utf8.
